### PR TITLE
Add coverageThreshold as an allowed Jest option

### DIFF
--- a/fusion-cli/build/jest/cli-options.js
+++ b/fusion-cli/build/jest/cli-options.js
@@ -14,6 +14,7 @@ exports.allowedJestOptions = [
   'ci',
   'clearCache',
   'collectCoverageFrom',
+  'coverageThreshold',
   'colors',
   'coverage',
   'collectCoverage',


### PR DESCRIPTION
coverageThreshold will allow a developer to choose which test percentages to fail on, which could prevent a build from being deployed without proper test coverage. By default Fusion does not fail the build when there is no coverage from what I can tell.